### PR TITLE
Remove duplicate gallery from being registered

### DIFF
--- a/lib/register-blocks.php
+++ b/lib/register-blocks.php
@@ -17,7 +17,6 @@ function register_blocks() {
     $blocks = [
         "jsforwpadvblocks/gallery",
         "jsforwpadvblocks/data-example",
-        "jsforwpadvblocks/gallery",
     ];
 
     // Register each block with same CSS and JS


### PR DESCRIPTION
Fixes PHP notice: WP_Block_Type_Registry::register was called incorrectly. Block type "jsforwpadvblocks/gallery" is already registered.